### PR TITLE
Remove default ratatui features from lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bitflags = "2.6.0"
 crossterm = { version = "0.27.0", optional = true }
 derive_builder = "0.20.1"
 itertools = "0.13.0"
-ratatui = { version= "0.27.0", features = ["unstable-widget-ref"] }
+ratatui = { version= "0.27.0", features = ["unstable-widget-ref"], default-features = false }
 strum = { version = "0.26.3", features = ["derive"] }
 termion = { version = "4.0.2", optional = true }
 termwiz = { version = "0.22.0", optional = true }
@@ -25,6 +25,7 @@ color-eyre = "0.6.3"
 rand = "0.8.5"
 rstest = "0.22.0"
 strum = { version = "0.26.3", features = ["derive"] }
+ratatui = { version= "0.27.0", features = ["unstable-widget-ref"] }
 
 [features]
 default = ["crossterm"]


### PR DESCRIPTION
I am compiling to wasm and I cannot have the crossterm library in my transitive dependencies.